### PR TITLE
[java] modify the async recognition interface

### DIFF
--- a/audio-streaming-client-java/build.gradle.kts
+++ b/audio-streaming-client-java/build.gradle.kts
@@ -15,7 +15,7 @@ val kotlinVersion by extra("1.3.10")
 val grpcVersion by extra("1.16.1")
 
 group = "com.baidu.acu.pie"
-version = "0.8.3"
+version = "0.8.5"
 
 repositories {
     mavenLocal()
@@ -58,16 +58,10 @@ protobuf {
     }
 }
 
-task<Jar>("sourcesJar") {
-    from(sourceSets["main"].allJava)
-    classifier = "sources"
-}
-
 publishing {
     publications {
-        create<MavenPublication>("mavenJava") {
+        register<MavenPublication>("mavenJava") {
             from(components["java"])
-            artifact(tasks["sourcesJar"])
         }
     }
 }

--- a/audio-streaming-client-java/src/main/java/com/baidu/acu/pie/client/AsrClient.java
+++ b/audio-streaming-client-java/src/main/java/com/baidu/acu/pie/client/AsrClient.java
@@ -2,13 +2,15 @@
 
 package com.baidu.acu.pie.client;
 
-import java.io.InputStream;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.function.Consumer;
 
+import com.baidu.acu.pie.AudioStreaming.AudioFragmentRequest;
 import com.baidu.acu.pie.model.RecognitionResult;
+
+import io.grpc.stub.StreamObserver;
 
 /**
  * AsrClient
@@ -16,6 +18,8 @@ import com.baidu.acu.pie.model.RecognitionResult;
  * @author Shu Lingjie(shulingjie@baidu.com)
  */
 public interface AsrClient {
+    int getFragmentSize();
+
     /**
      * 同步识别，输入一个音频文件，线程会进入等待，直到识别完毕，返回结果
      * 通常用于对实时性要求不高的场景，如离线语音分析
@@ -28,11 +32,13 @@ public interface AsrClient {
      * 异步识别，输入一个语音流，会准实时返回每个句子的结果
      * 用于对实时性要求较高的场景，如会议记录
      *
-     * @param audioStream
      * @param resultConsumer
+     *
      * @return CountDownLatch，来自jdk1.5标准库，具体用法请参见 java doc
      */
-    CountDownLatch asyncRecognize(InputStream audioStream, Consumer<RecognitionResult> resultConsumer);
+    StreamObserver<AudioFragmentRequest> asyncRecognize(
+            Consumer<RecognitionResult> resultConsumer,
+            CountDownLatch finishLatch);
 
     void shutdown();
 }

--- a/audio-streaming-client-java/src/main/java/com/baidu/acu/pie/demo/JavaDemo.java
+++ b/audio-streaming-client-java/src/main/java/com/baidu/acu/pie/demo/JavaDemo.java
@@ -1,0 +1,103 @@
+// Copyright (C) 2019 Baidu Inc. All rights reserved.
+
+package com.baidu.acu.pie.demo;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import com.baidu.acu.pie.AudioStreaming.AudioFragmentRequest;
+import com.baidu.acu.pie.client.AsrClient;
+import com.baidu.acu.pie.client.AsrClientFactory;
+import com.baidu.acu.pie.model.AsrConfig;
+import com.baidu.acu.pie.model.AsrProduct;
+import com.baidu.acu.pie.model.RecognitionResult;
+import com.google.protobuf.ByteString;
+
+import io.grpc.stub.StreamObserver;
+
+/**
+ * JavaDemo
+ *
+ * @author Shu Lingjie(shulingjie@baidu.com)
+ */
+public class JavaDemo {
+    public static void main(String[] args) {
+        JavaDemo javaDemo = new JavaDemo();
+        javaDemo.asyncRecognition();
+    }
+
+    private AsrClient createAsrClient() {
+        // asrConfig构造后就不可修改
+        AsrConfig asrConfig = new AsrConfig()
+                .serverIp("180.76.107.131")
+                .serverPort(8050)
+                .appName("simple demo")
+                .product(AsrProduct.CUSTOMER_SERVICE);
+
+        return AsrClientFactory.buildClient(asrConfig);
+    }
+
+    public void recognizeFile() {
+        String audioFilePath = "testaudio/bj8k.wav";
+        AsrClient asrClient = createAsrClient();
+        List<RecognitionResult> results = asrClient.syncRecognize(Paths.get(audioFilePath));
+
+        // don't forget to shutdown !!!
+        asrClient.shutdown();
+
+        for (RecognitionResult result : results) {
+            System.out.println(String.format(AsrConfig.TITLE_FORMAT,
+                    "serial_num",
+                    "err_no",
+                    "err_message",
+                    "start_time",
+                    "end_time",
+                    "result"));
+            System.out.println(String.format(AsrConfig.TITLE_FORMAT,
+                    result.getSerialNum(),
+                    result.getErrorCode(),
+                    result.getErrorMessage(),
+                    result.getStartTime(),
+                    result.getEndTime(),
+                    result.getResult()
+            ));
+        }
+    }
+
+    public void asyncRecognition() {
+        // 使用长音频来模拟不断输入的情况
+        String longAudioFilePath = "testaudio/1.wav";
+        AsrClient asrClient = createAsrClient();
+
+        try (InputStream audioStream = Files.newInputStream(Paths.get(longAudioFilePath))) {
+            byte[] data = new byte[asrClient.getFragmentSize()];
+            int readSize;
+
+            CountDownLatch finishLatch = new CountDownLatch(1);
+            StreamObserver<AudioFragmentRequest> sender = asrClient.asyncRecognize(it -> {
+                System.out.println(it);
+            }, finishLatch);
+
+            while ((readSize = audioStream.read(data)) != -1) {
+                sender.onNext(AudioFragmentRequest.newBuilder()
+                        .setAudioData(ByteString.copyFrom(data, 0, readSize))
+                        .build());
+            }
+
+            // wait to ensure to receive the last response
+            finishLatch.await(1000, TimeUnit.SECONDS);
+        } catch (IOException e) {
+            e.printStackTrace();
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+
+        asrClient.shutdown();
+        System.out.println("all task finished");
+    }
+}


### PR DESCRIPTION
原来想的太简单了，设计的接口并不能适配 android 端 MediaRecorder 和 AudioRecorder的使用方法。
现在为了让用户能方便的发送，直接暴露了 StreamObserver，后面考虑定义一个接口类，把这个 StreamObserver 隐藏掉。